### PR TITLE
Multiple Request Completion PR

### DIFF
--- a/build-probe-mpi/src/lib.rs
+++ b/build-probe-mpi/src/lib.rs
@@ -5,7 +5,7 @@
 #![warn(unused_extern_crates)]
 #![warn(unused_import_braces)]
 #![warn(unused_qualifications)]
-#![allow(clippy::unknown_clippy_lints)]
+#![allow(unknown_lints)]
 
 //! Probe an environment for an installed MPI library
 //!

--- a/examples/immediate.rs
+++ b/examples/immediate.rs
@@ -41,14 +41,14 @@ fn main() {
 
     y = 0.0;
     mpi::request::scope(|scope| {
-        let _sreq: WaitGuard<_> = world
+        let _sreq: WaitGuard<_, _> = world
             .this_process()
             .immediate_synchronous_send(scope, &x)
             .into();
         let preq = world.any_process().immediate_matched_probe();
         assert!(preq.is_some());
         let (msg, _) = preq.unwrap();
-        let _rreq: WaitGuard<_> = msg.immediate_matched_receive_into(scope, &mut y).into();
+        let _rreq: WaitGuard<_, _> = msg.immediate_matched_receive_into(scope, &mut y).into();
     });
     assert_eq!(x, y);
 

--- a/examples/immediate_barrier_multiple.rs
+++ b/examples/immediate_barrier_multiple.rs
@@ -1,0 +1,112 @@
+/// Example using different types of requests with a request collection.
+use mpi;
+use mpi::traits::*;
+
+#[cfg(msmpi)]
+fn main() {
+}
+
+const COUNT: usize = 128;
+
+#[cfg(not(msmpi))]
+fn main() {
+    let universe = mpi::initialize().unwrap();
+    let world = universe.world();
+
+    // Try wait_any()
+    mpi::request::multiple_scope(COUNT, |_, coll| {
+        for _ in 0..COUNT {
+            let req = world.immediate_barrier();
+            coll.add(req);
+        }
+        while coll.incomplete() > 0 {
+            coll.wait_any().unwrap();
+        }
+    });
+
+    // Try wait_some()
+    mpi::request::multiple_scope(COUNT, |_, coll| {
+        for _ in 0..COUNT {
+            let req = world.immediate_barrier();
+            coll.add(req);
+        }
+        let mut result = vec![None; COUNT];
+        while coll.incomplete() > 0 {
+            let count = coll.wait_some(&mut result);
+            let mut i = 0;
+            for elm in result.iter() {
+                if let Some(_) = elm {
+                    i += 1;
+                }
+            }
+            assert_eq!(i, count);
+        }
+    });
+
+    // Try wait_all()
+    mpi::request::multiple_scope(COUNT, |_, coll| {
+        for _ in 0..COUNT {
+            let req = world.immediate_barrier();
+            coll.add(req);
+        }
+        let mut result = vec![None; COUNT ];
+        coll.wait_all(&mut result);
+        assert!(result.iter().all(|elm| elm.is_some()));
+    });
+
+    // Try test_any()
+    mpi::request::multiple_scope(COUNT, |_, coll| {
+        for _ in 0..COUNT {
+            let req = world.immediate_barrier();
+            coll.add(req);
+        }
+        let mut finished = 0;
+        while coll.incomplete() > 0 {
+            if coll.test_any().is_some() {
+                finished += 1;
+            }
+            assert_eq!(coll.incomplete(), COUNT - finished);
+        }
+        assert_eq!(finished, COUNT);
+    });
+
+    // Try test_some()
+    mpi::request::multiple_scope(COUNT, |_, coll| {
+        for _ in 0..COUNT {
+            let req = world.immediate_barrier();
+            coll.add(req);
+        }
+        let mut result = vec![None; COUNT];
+        let mut finished = 0;
+        while coll.incomplete() > 0 {
+            let count = coll.test_some(&mut result);
+            finished += count;
+            if count > 0 {
+                let mut i = 0;
+                for elm in result.iter() {
+                    if let Some(_) = elm {
+                        i += 1;
+                    }
+                }
+                assert_eq!(i, count);
+            }
+            assert_eq!(coll.incomplete(), COUNT - finished);
+        }
+        assert_eq!(finished, COUNT);
+    });
+
+    // Try test_all()
+    mpi::request::multiple_scope(COUNT, |_, coll| {
+        for _ in 0..COUNT {
+            let req = world.immediate_barrier();
+            coll.add(req);
+        }
+        let mut result = vec![None; COUNT];
+        while coll.incomplete() > 0 {
+            if coll.test_all(&mut result) {
+                assert_eq!(coll.incomplete(), 0);
+            }
+        }
+        assert!(result.iter().all(|elm| elm.is_some()));
+    });
+}

--- a/examples/immediate_multiple_requests.rs
+++ b/examples/immediate_multiple_requests.rs
@@ -1,0 +1,152 @@
+//! Example using request handlers.
+use mpi;
+use mpi::point_to_point::Status;
+use mpi::traits::*;
+
+const COUNT: usize = 256;
+
+fn main() {
+    let universe = mpi::initialize().unwrap();
+    let world = universe.world();
+    let size = world.size();
+    let rank = world.rank();
+
+    let x: i32 = 100;
+    let mut y: i32 = 0;
+
+    mpi::request::scope(|scope| {
+        let sreq = world.this_process().immediate_send(scope, &x);
+        let rreq = world.any_process().immediate_receive_into(scope, &mut y);
+        let result = rreq.wait_for_data();
+        assert_eq!(*result, x);
+        sreq.wait();
+    });
+
+    // Test wait_any()
+    let mut result: Vec<i32> = vec![0; COUNT];
+    mpi::request::multiple_scope(2 * COUNT, |scope, coll| {
+        let prev_proc = if rank > 0 { rank - 1 } else { size - 1 };
+        let next_proc = (rank + 1) % size;
+        for _ in 0..result.len() {
+            let sreq = world
+                .process_at_rank(next_proc)
+                .immediate_send(scope, &rank);
+            coll.add(sreq);
+        }
+        for val in result.iter_mut() {
+            let rreq = world
+                .process_at_rank(prev_proc)
+                .immediate_receive_into(scope, val);
+            coll.add(rreq);
+        }
+        let mut send_count = 0;
+        let mut recv_count = 0;
+        while coll.incomplete() > 0 {
+            let (_, _, result) = coll.wait_any().unwrap();
+            if *result == rank {
+                send_count += 1;
+            } else {
+                recv_count += 1;
+            }
+        }
+        assert_eq!(send_count, COUNT);
+        assert_eq!(recv_count, COUNT);
+    });
+
+    let mut result: Vec<i32> = vec![0; COUNT];
+    // Test wait_some()
+    mpi::request::multiple_scope(2 * COUNT, |scope, coll| {
+        let prev_proc = if rank > 0 { rank - 1 } else { size - 1 };
+        let next_proc = (rank + 1) % size;
+        for _ in 0..result.len() {
+            let sreq = world
+                .process_at_rank(next_proc)
+                .immediate_send(scope, &rank);
+            coll.add(sreq);
+        }
+        for val in result.iter_mut() {
+            let rreq = world
+                .process_at_rank(prev_proc)
+                .immediate_receive_into(scope, val);
+            coll.add(rreq);
+        }
+        let mut send_count = 0;
+        let mut recv_count = 0;
+        let mut some_buf: Vec<Option<(usize, Status, &i32)>> = vec![None; 2 * COUNT];
+        while coll.incomplete() > 0 {
+            let count = coll.wait_some(&mut some_buf);
+            println!("wait_some(): {} request(s) completed", count);
+            assert!(some_buf.iter().any(|elm| elm.is_some()));
+            for elm in some_buf.iter() {
+                if let Some((_, _, result)) = elm {
+                    if **result == rank {
+                        send_count += 1;
+                    } else {
+                        recv_count += 1;
+                    }
+                }
+            }
+        }
+        assert_eq!(send_count, COUNT);
+        assert_eq!(recv_count, COUNT);
+    });
+
+    let mut result: Vec<i32> = vec![0; COUNT];
+    // Test wait_all()
+    mpi::request::multiple_scope(2 * COUNT, |scope, coll| {
+        let prev_proc = if rank > 0 { rank - 1 } else { size - 1 };
+        let next_proc = (rank + 1) % size;
+        for _ in 0..result.len() {
+            let sreq = world
+                .process_at_rank(next_proc)
+                .immediate_send(scope, &rank);
+            coll.add(sreq);
+        }
+        for val in result.iter_mut() {
+            let rreq = world
+                .process_at_rank(prev_proc)
+                .immediate_receive_into(scope, val);
+            coll.add(rreq);
+        }
+        let mut out: Vec<Option<(usize, Status, &i32)>> = vec![None; 2 * COUNT];
+        coll.wait_all(&mut out);
+        let mut send_count = 0;
+        let mut recv_count = 0;
+        for elm in out {
+            let (_, _, result) = elm.unwrap();
+            if *result == rank {
+                send_count += 1;
+            } else {
+                recv_count += 1;
+            }
+        }
+        assert_eq!(send_count, COUNT);
+        assert_eq!(recv_count, COUNT);
+    });
+
+    // Check wait_*() with a buffer of increasing values
+    let x: Vec<i32> = (0..COUNT as i32).collect();
+    let mut result: Vec<i32> = vec![0; COUNT];
+    mpi::request::multiple_scope(COUNT, |scope, coll| {
+        let prev_proc = if rank > 0 { rank - 1 } else { size - 1 };
+        let next_proc = (rank + 1) % size;
+        for elm in &x {
+            let sreq = world
+                .process_at_rank(next_proc)
+                .immediate_send(scope, elm);
+            coll.add(sreq);
+        }
+        for val in result.iter_mut() {
+            let rreq = world
+                .process_at_rank(prev_proc)
+                .immediate_receive_into(scope, val);
+            coll.add(rreq);
+        }
+        let mut out: Vec<Option<(usize, Status, &i32)>> = vec![None; 2 * COUNT];
+        coll.wait_all(&mut out);
+        assert!(out.iter().all(|elm| elm.is_some()));
+    });
+    // Ensure the result and x are an incrementing array of integers
+    result.sort();
+    assert_eq!(result, x);
+}

--- a/examples/immediate_multiple_test.rs
+++ b/examples/immediate_multiple_test.rs
@@ -1,0 +1,97 @@
+/// Example showing usage of test_any(), test_some() and test_all().
+use mpi;
+use mpi::Rank;
+use mpi::traits::*;
+use mpi::request::{Scope, RequestCollection};
+
+const COUNT: usize = 128;
+
+/// Send and receive COUNT number of immediate requests.
+fn send_recv<'a, C: Communicator, S: Scope<'a> + Copy>(
+    world: C,
+    scope: S,
+    coll: &mut RequestCollection<'a, [i32; 4]>,
+    next_proc: Rank,
+    prev_proc: Rank,
+    x: &'a [[i32; 4]],
+    recv: &'a mut [[i32; 4]],
+) {
+    for elm in x {
+        let sreq = world
+            .process_at_rank(next_proc)
+            .immediate_send(scope, elm);
+        coll.add(sreq);
+    }
+    for elm in recv.iter_mut() {
+        let rreq = world
+            .process_at_rank(prev_proc)
+            .immediate_receive_into(scope, elm);
+        coll.add(rreq);
+    }
+}
+
+/// Ensure that the result buffer, containing the data for both send and receive
+/// requests, matches what was sent in the buffer x.
+fn check_result_buffer(x: &[[i32; 4]], mut result_buf: Vec<[i32; 4]>) {
+    result_buf.sort();
+    assert_eq!(result_buf.len(), 2 * x.len());
+    for (i, x_val) in x.iter().enumerate() {
+        // The result buffer has both send values and receive values
+        assert_eq!(result_buf[2 * i], *x_val);
+        assert_eq!(result_buf[2 * i + 1], *x_val);
+    }
+}
+
+fn main() {
+    let universe = mpi::initialize().unwrap();
+    let world = universe.world();
+    let rank = world.rank();
+    let size = world.size();
+
+    let next_proc = (rank + 1) % size;
+    let prev_proc = if rank > 0 { rank - 1 } else { size - 1 };
+
+    let x: Vec<[i32; 4]> = (0..COUNT as i32).map(|i| [i, i + 1, i + 2, i + 3]).collect();
+    let mut recv: Vec<[i32; 4]> = vec![[0, 0, 0, 0]; COUNT];
+    mpi::request::multiple_scope(COUNT, |scope, coll| {
+        send_recv(world, scope, coll, next_proc, prev_proc, &x, &mut recv);
+
+        let mut buf = vec![];
+        while coll.incomplete() > 0 {
+            if let Some((_, _, data)) = coll.test_any() {
+                buf.push(*data);
+            }
+        }
+        check_result_buffer(&x, buf);
+    });
+
+    let mut recv: Vec<[i32; 4]> = vec![[0, 0, 0, 0]; COUNT];
+    mpi::request::multiple_scope(COUNT, |scope, coll| {
+        send_recv(world, scope, coll, next_proc, prev_proc, &x, &mut recv);
+
+        let mut complete = vec![None; 2 * COUNT];
+        let mut buf = vec![];
+        while coll.incomplete() > 0 {
+            let count = coll.test_some(&mut complete);
+            if count > 0 {
+                println!("test_some(): {} request(s) completed", count);
+                for elm in complete.iter() {
+                    if let Some((_, _, data)) = elm {
+                        buf.push(**data);
+                    }
+                }
+            }
+        }
+        check_result_buffer(&x, buf);
+    });
+
+    let mut recv: Vec<[i32; 4]> = vec![[0, 0, 0, 0]; COUNT];
+    mpi::request::multiple_scope(COUNT, |scope, coll| {
+        send_recv(world, scope, coll, next_proc, prev_proc, &x, &mut recv);
+
+        let mut complete = vec![None; 2 * COUNT];
+        while !coll.test_all(&mut complete) { }
+        let buf: Vec<[i32; 4]> = complete.iter().map(|elm| *elm.unwrap().2).collect();
+        check_result_buffer(&x, buf);
+    });
+}

--- a/src/collective.rs
+++ b/src/collective.rs
@@ -310,10 +310,11 @@ pub trait CommunicatorCollectives: Communicator {
     /// # Standard section(s)
     ///
     /// 5.12.1
-    fn immediate_barrier(&self) -> Request<'static> {
+    fn immediate_barrier(&self) -> Request<'static, ()> {
         unsafe {
             Request::from_raw(
                 with_uninitialized(|request| ffi::MPI_Ibarrier(self.as_raw(), request)).1,
+                &(),
                 StaticScope,
             )
         }
@@ -329,12 +330,12 @@ pub trait CommunicatorCollectives: Communicator {
     /// # Standard section(s)
     ///
     /// 5.12.5
-    fn immediate_all_gather_into<'a, Sc, S: ?Sized, R: ?Sized>(
+    fn immediate_all_gather_into<'a, S: ?Sized, R: ?Sized, Sc>(
         &self,
         scope: Sc,
         sendbuf: &'a S,
         recvbuf: &'a mut R,
-    ) -> Request<'a, Sc>
+    ) -> Request<'a, R, Sc>
     where
         S: 'a + Buffer,
         R: 'a + BufferMut,
@@ -356,6 +357,7 @@ pub trait CommunicatorCollectives: Communicator {
                     )
                 })
                 .1,
+                recvbuf,
                 scope,
             )
         }
@@ -371,12 +373,12 @@ pub trait CommunicatorCollectives: Communicator {
     /// # Standard section(s)
     ///
     /// 5.12.5
-    fn immediate_all_gather_varcount_into<'a, Sc, S: ?Sized, R: ?Sized>(
+    fn immediate_all_gather_varcount_into<'a, S: ?Sized, R: ?Sized, Sc>(
         &self,
         scope: Sc,
         sendbuf: &'a S,
         recvbuf: &'a mut R,
-    ) -> Request<'a, Sc>
+    ) -> Request<'a, R, Sc>
     where
         S: 'a + Buffer,
         R: 'a + PartitionedBufferMut,
@@ -398,6 +400,7 @@ pub trait CommunicatorCollectives: Communicator {
                     )
                 })
                 .1,
+                recvbuf,
                 scope,
             )
         }
@@ -412,12 +415,12 @@ pub trait CommunicatorCollectives: Communicator {
     /// # Standard section(s)
     ///
     /// 5.12.6
-    fn immediate_all_to_all_into<'a, Sc, S: ?Sized, R: ?Sized>(
+    fn immediate_all_to_all_into<'a, S: ?Sized, R: ?Sized, Sc>(
         &self,
         scope: Sc,
         sendbuf: &'a S,
         recvbuf: &'a mut R,
-    ) -> Request<'a, Sc>
+    ) -> Request<'a, R, Sc>
     where
         S: 'a + Buffer,
         R: 'a + BufferMut,
@@ -439,6 +442,7 @@ pub trait CommunicatorCollectives: Communicator {
                     )
                 })
                 .1,
+                recvbuf,
                 scope,
             )
         }
@@ -449,12 +453,12 @@ pub trait CommunicatorCollectives: Communicator {
     /// # Standard section(s)
     ///
     /// 5.12.6
-    fn immediate_all_to_all_varcount_into<'a, Sc, S: ?Sized, R: ?Sized>(
+    fn immediate_all_to_all_varcount_into<'a, S: ?Sized, R: ?Sized, Sc>(
         &self,
         scope: Sc,
         sendbuf: &'a S,
         recvbuf: &'a mut R,
-    ) -> Request<'a, Sc>
+    ) -> Request<'a, R, Sc>
     where
         S: 'a + PartitionedBuffer,
         R: 'a + PartitionedBufferMut,
@@ -477,6 +481,7 @@ pub trait CommunicatorCollectives: Communicator {
                     )
                 })
                 .1,
+                recvbuf,
                 scope,
             )
         }
@@ -492,13 +497,13 @@ pub trait CommunicatorCollectives: Communicator {
     /// # Standard section(s)
     ///
     /// 5.12.8
-    fn immediate_all_reduce_into<'a, Sc, S: ?Sized, R: ?Sized, O>(
+    fn immediate_all_reduce_into<'a, S: ?Sized, R: ?Sized, O, Sc>(
         &self,
         scope: Sc,
         sendbuf: &'a S,
         recvbuf: &'a mut R,
         op: O,
-    ) -> Request<'a, Sc>
+    ) -> Request<'a, R, Sc>
     where
         S: 'a + Buffer,
         R: 'a + BufferMut,
@@ -519,6 +524,7 @@ pub trait CommunicatorCollectives: Communicator {
                     )
                 })
                 .1,
+                recvbuf,
                 scope,
             )
         }
@@ -535,13 +541,13 @@ pub trait CommunicatorCollectives: Communicator {
     /// # Standard section(s)
     ///
     /// 5.12.9
-    fn immediate_reduce_scatter_block_into<'a, Sc, S: ?Sized, R: ?Sized, O>(
+    fn immediate_reduce_scatter_block_into<'a, S: ?Sized, R: ?Sized, O, Sc>(
         &self,
         scope: Sc,
         sendbuf: &'a S,
         recvbuf: &'a mut R,
         op: O,
-    ) -> Request<'a, Sc>
+    ) -> Request<'a, R, Sc>
     where
         S: 'a + Buffer,
         R: 'a + BufferMut,
@@ -563,6 +569,7 @@ pub trait CommunicatorCollectives: Communicator {
                     )
                 })
                 .1,
+                recvbuf,
                 scope,
             )
         }
@@ -578,13 +585,13 @@ pub trait CommunicatorCollectives: Communicator {
     /// # Standard section(s)
     ///
     /// 5.12.11
-    fn immediate_scan_into<'a, Sc, S: ?Sized, R: ?Sized, O>(
+    fn immediate_scan_into<'a, S: ?Sized, R: ?Sized, O, Sc>(
         &self,
         scope: Sc,
         sendbuf: &'a S,
         recvbuf: &'a mut R,
         op: O,
-    ) -> Request<'a, Sc>
+    ) -> Request<'a, R, Sc>
     where
         S: 'a + Buffer,
         R: 'a + BufferMut,
@@ -605,6 +612,7 @@ pub trait CommunicatorCollectives: Communicator {
                     )
                 })
                 .1,
+                recvbuf,
                 scope,
             )
         }
@@ -620,13 +628,13 @@ pub trait CommunicatorCollectives: Communicator {
     /// # Standard section(s)
     ///
     /// 5.12.12
-    fn immediate_exclusive_scan_into<'a, Sc, S: ?Sized, R: ?Sized, O>(
+    fn immediate_exclusive_scan_into<'a, S: ?Sized, R: ?Sized, O, Sc>(
         &self,
         scope: Sc,
         sendbuf: &'a S,
         recvbuf: &'a mut R,
         op: O,
-    ) -> Request<'a, Sc>
+    ) -> Request<'a, R, Sc>
     where
         S: 'a + Buffer,
         R: 'a + BufferMut,
@@ -647,6 +655,7 @@ pub trait CommunicatorCollectives: Communicator {
                     )
                 })
                 .1,
+                recvbuf,
                 scope,
             )
         }
@@ -1056,11 +1065,11 @@ pub trait Root: AsCommunicator {
     /// # Standard section(s)
     ///
     /// 5.12.2
-    fn immediate_broadcast_into<'a, Sc, Buf: ?Sized>(
+    fn immediate_broadcast_into<'a, Buf: ?Sized, Sc>(
         &self,
         scope: Sc,
         buf: &'a mut Buf,
-    ) -> Request<'a, Sc>
+    ) -> Request<'a, Buf, Sc>
     where
         Buf: 'a + BufferMut,
         Sc: Scope<'a>,
@@ -1078,6 +1087,7 @@ pub trait Root: AsCommunicator {
                     )
                 })
                 .1,
+                buf,
                 scope,
             )
         }
@@ -1094,7 +1104,11 @@ pub trait Root: AsCommunicator {
     /// # Standard section(s)
     ///
     /// 5.12.3
-    fn immediate_gather_into<'a, Sc, S: ?Sized>(&self, scope: Sc, sendbuf: &'a S) -> Request<'a, Sc>
+    fn immediate_gather_into<'a, S: ?Sized, Sc>(
+        &self,
+        scope: Sc,
+        sendbuf: &'a S,
+    ) -> Request<'a, S, Sc>
     where
         S: 'a + Buffer,
         Sc: Scope<'a>,
@@ -1116,6 +1130,7 @@ pub trait Root: AsCommunicator {
                     )
                 })
                 .1,
+                sendbuf,
                 scope,
             )
         }
@@ -1132,12 +1147,12 @@ pub trait Root: AsCommunicator {
     /// # Standard section(s)
     ///
     /// 5.12.3
-    fn immediate_gather_into_root<'a, Sc, S: ?Sized, R: ?Sized>(
+    fn immediate_gather_into_root<'a, S: ?Sized, R: ?Sized, Sc>(
         &self,
         scope: Sc,
         sendbuf: &'a S,
         recvbuf: &'a mut R,
-    ) -> Request<'a, Sc>
+    ) -> Request<'a, R, Sc>
     where
         S: 'a + Buffer,
         R: 'a + BufferMut,
@@ -1161,6 +1176,7 @@ pub trait Root: AsCommunicator {
                     )
                 })
                 .1,
+                recvbuf,
                 scope,
             )
         }
@@ -1181,7 +1197,7 @@ pub trait Root: AsCommunicator {
         &self,
         scope: Sc,
         sendbuf: &'a S,
-    ) -> Request<'a, Sc>
+    ) -> Request<'a, S, Sc>
     where
         S: 'a + Buffer,
         Sc: Scope<'a>,
@@ -1204,6 +1220,7 @@ pub trait Root: AsCommunicator {
                     )
                 })
                 .1,
+                sendbuf,
                 scope,
             )
         }
@@ -1225,7 +1242,7 @@ pub trait Root: AsCommunicator {
         scope: Sc,
         sendbuf: &'a S,
         recvbuf: &'a mut R,
-    ) -> Request<'a, Sc>
+    ) -> Request<'a, R, Sc>
     where
         S: 'a + Buffer,
         R: 'a + PartitionedBufferMut,
@@ -1249,6 +1266,7 @@ pub trait Root: AsCommunicator {
                     )
                 })
                 .1,
+                recvbuf,
                 scope,
             )
         }
@@ -1269,7 +1287,7 @@ pub trait Root: AsCommunicator {
         &self,
         scope: Sc,
         recvbuf: &'a mut R,
-    ) -> Request<'a, Sc>
+    ) -> Request<'a, R, Sc>
     where
         R: 'a + BufferMut,
         Sc: Scope<'a>,
@@ -1291,6 +1309,7 @@ pub trait Root: AsCommunicator {
                     )
                 })
                 .1,
+                recvbuf,
                 scope,
             )
         }
@@ -1312,7 +1331,7 @@ pub trait Root: AsCommunicator {
         scope: Sc,
         sendbuf: &'a S,
         recvbuf: &'a mut R,
-    ) -> Request<'a, Sc>
+    ) -> Request<'a, R, Sc>
     where
         S: 'a + Buffer,
         R: 'a + BufferMut,
@@ -1336,6 +1355,7 @@ pub trait Root: AsCommunicator {
                     )
                 })
                 .1,
+                recvbuf,
                 scope,
             )
         }
@@ -1356,7 +1376,7 @@ pub trait Root: AsCommunicator {
         &self,
         scope: Sc,
         recvbuf: &'a mut R,
-    ) -> Request<'a, Sc>
+    ) -> Request<'a, R, Sc>
     where
         R: 'a + BufferMut,
         Sc: Scope<'a>,
@@ -1379,6 +1399,7 @@ pub trait Root: AsCommunicator {
                     )
                 })
                 .1,
+                recvbuf,
                 scope,
             )
         }
@@ -1400,7 +1421,7 @@ pub trait Root: AsCommunicator {
         scope: Sc,
         sendbuf: &'a S,
         recvbuf: &'a mut R,
-    ) -> Request<'a, Sc>
+    ) -> Request<'a, R, Sc>
     where
         S: 'a + PartitionedBuffer,
         R: 'a + BufferMut,
@@ -1424,6 +1445,7 @@ pub trait Root: AsCommunicator {
                     )
                 })
                 .1,
+                recvbuf,
                 scope,
             )
         }
@@ -1446,7 +1468,7 @@ pub trait Root: AsCommunicator {
         scope: Sc,
         sendbuf: &'a S,
         op: O,
-    ) -> Request<'a, Sc>
+    ) -> Request<'a, S, Sc>
     where
         S: 'a + Buffer,
         O: 'a + Operation,
@@ -1468,6 +1490,7 @@ pub trait Root: AsCommunicator {
                     )
                 })
                 .1,
+                sendbuf,
                 scope,
             )
         }
@@ -1491,7 +1514,7 @@ pub trait Root: AsCommunicator {
         sendbuf: &'a S,
         recvbuf: &'a mut R,
         op: O,
-    ) -> Request<'a, Sc>
+    ) -> Request<'a, R, Sc>
     where
         S: 'a + Buffer,
         R: 'a + BufferMut,
@@ -1514,6 +1537,7 @@ pub trait Root: AsCommunicator {
                     )
                 })
                 .1,
+                recvbuf,
                 scope,
             )
         }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -179,6 +179,8 @@ pub type Count = c_int;
 pub type Tag = c_int;
 /// An address in memory
 pub type Address = MPI_Aint;
+/// Rank of each process.
+pub type Rank = c_int;
 
 /// IntArray is used to translate Rust bool values to and from the int-bool types preferred by MPI
 /// without incurring allocation in the common case.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -5,7 +5,7 @@
 #![warn(unused_extern_crates)]
 #![warn(unused_import_braces)]
 #![warn(unused_qualifications)]
-#![allow(clippy::unknown_clippy_lints)]
+#![allow(unknown_lints)]
 #![allow(renamed_and_removed_lints)]
 #![allow(clippy::needless_doctest_main)]
 #![warn(clippy::cast_possible_truncation)]
@@ -179,8 +179,8 @@ pub type Count = c_int;
 pub type Tag = c_int;
 /// An address in memory
 pub type Address = MPI_Aint;
-/// Rank of each process.
-pub type Rank = c_int;
+/// Reexport the Rank type
+pub use crate::topology::Rank;
 
 /// IntArray is used to translate Rust bool values to and from the int-bool types preferred by MPI
 /// without incurring allocation in the common case.

--- a/src/point_to_point.rs
+++ b/src/point_to_point.rs
@@ -281,7 +281,7 @@ pub unsafe trait Source: AsCommunicator {
         scope: Sc,
         buf: &'a mut Buf,
         tag: Tag,
-    ) -> Request<'a, Sc>
+    ) -> Request<'a, Buf, Sc>
     where
         Buf: 'a + BufferMut,
         Sc: Scope<'a>,
@@ -300,6 +300,7 @@ pub unsafe trait Source: AsCommunicator {
                     )
                 })
                 .1,
+                buf,
                 scope,
             )
         }
@@ -319,7 +320,7 @@ pub unsafe trait Source: AsCommunicator {
         &self,
         scope: Sc,
         buf: &'a mut Buf,
-    ) -> Request<'a, Sc>
+    ) -> Request<'a, Buf, Sc>
     where
         Buf: 'a + BufferMut,
         Sc: Scope<'a>,
@@ -351,7 +352,7 @@ pub unsafe trait Source: AsCommunicator {
             });
             ReceiveFuture {
                 val,
-                req: Request::from_raw(request, StaticScope),
+                req: Request::from_raw(request, &(), StaticScope),
             }
         }
     }
@@ -676,7 +677,7 @@ pub trait Destination: AsCommunicator {
         scope: Sc,
         buf: &'a Buf,
         tag: Tag,
-    ) -> Request<'a, Sc>
+    ) -> Request<'a, Buf, Sc>
     where
         Buf: 'a + Buffer,
         Sc: Scope<'a>,
@@ -695,6 +696,7 @@ pub trait Destination: AsCommunicator {
                     )
                 })
                 .1,
+                buf,
                 scope,
             )
         }
@@ -710,7 +712,11 @@ pub trait Destination: AsCommunicator {
     /// # Standard section(s)
     ///
     /// 3.7.2
-    fn immediate_send<'a, Sc, Buf: ?Sized>(&self, scope: Sc, buf: &'a Buf) -> Request<'a, Sc>
+    fn immediate_send<'a, Sc, Buf: ?Sized>(
+        &self,
+        scope: Sc,
+        buf: &'a Buf,
+    ) -> Request<'a, Buf, Sc>
     where
         Buf: 'a + Buffer,
         Sc: Scope<'a>,
@@ -730,7 +736,7 @@ pub trait Destination: AsCommunicator {
         scope: Sc,
         buf: &'a Buf,
         tag: Tag,
-    ) -> Request<'a, Sc>
+    ) -> Request<'a, Buf, Sc>
     where
         Buf: 'a + Buffer,
         Sc: Scope<'a>,
@@ -749,6 +755,7 @@ pub trait Destination: AsCommunicator {
                     )
                 })
                 .1,
+                buf,
                 scope,
             )
         }
@@ -765,7 +772,7 @@ pub trait Destination: AsCommunicator {
         &self,
         scope: Sc,
         buf: &'a Buf,
-    ) -> Request<'a, Sc>
+    ) -> Request<'a, Buf, Sc>
     where
         Buf: 'a + Buffer,
         Sc: Scope<'a>,
@@ -785,7 +792,7 @@ pub trait Destination: AsCommunicator {
         scope: Sc,
         buf: &'a Buf,
         tag: Tag,
-    ) -> Request<'a, Sc>
+    ) -> Request<'a, Buf, Sc>
     where
         Buf: 'a + Buffer,
         Sc: Scope<'a>,
@@ -804,6 +811,7 @@ pub trait Destination: AsCommunicator {
                     )
                 })
                 .1,
+                buf,
                 scope,
             )
         }
@@ -820,7 +828,7 @@ pub trait Destination: AsCommunicator {
         &self,
         scope: Sc,
         buf: &'a Buf,
-    ) -> Request<'a, Sc>
+    ) -> Request<'a, Buf, Sc>
     where
         Buf: 'a + Buffer,
         Sc: Scope<'a>,
@@ -840,7 +848,7 @@ pub trait Destination: AsCommunicator {
         scope: Sc,
         buf: &'a Buf,
         tag: Tag,
-    ) -> Request<'a, Sc>
+    ) -> Request<'a, Buf, Sc>
     where
         Buf: 'a + Buffer,
         Sc: Scope<'a>,
@@ -859,6 +867,7 @@ pub trait Destination: AsCommunicator {
                     )
                 })
                 .1,
+                buf,
                 scope,
             )
         }
@@ -875,7 +884,11 @@ pub trait Destination: AsCommunicator {
     /// # Standard section(s)
     ///
     /// 3.7.2
-    fn immediate_ready_send<'a, Sc, Buf: ?Sized>(&self, scope: Sc, buf: &'a Buf) -> Request<'a, Sc>
+    fn immediate_ready_send<'a, Sc, Buf: ?Sized>(
+        &self,
+        scope: Sc,
+        buf: &'a Buf,
+    ) -> Request<'a, Buf, Sc>
     where
         Buf: 'a + Buffer,
         Sc: Scope<'a>,
@@ -1016,7 +1029,7 @@ impl Message {
         mut self,
         scope: Sc,
         buf: &'a mut Buf,
-    ) -> Request<'a, Sc>
+    ) -> Request<'a, Buf, Sc>
     where
         Buf: BufferMut,
         Sc: Scope<'a>,
@@ -1033,7 +1046,7 @@ impl Message {
             })
             .1;
             assert_eq!(self.as_raw(), ffi::RSMPI_MESSAGE_NULL);
-            Request::from_raw(request, scope)
+            Request::from_raw(request, buf, scope)
         }
     }
 }
@@ -1320,7 +1333,7 @@ where
 #[must_use]
 pub struct ReceiveFuture<T> {
     val: *mut T,
-    req: Request<'static>,
+    req: Request<'static, ()>,
 }
 
 impl<T> ReceiveFuture<T>

--- a/src/point_to_point.rs
+++ b/src/point_to_point.rs
@@ -712,11 +712,7 @@ pub trait Destination: AsCommunicator {
     /// # Standard section(s)
     ///
     /// 3.7.2
-    fn immediate_send<'a, Sc, Buf: ?Sized>(
-        &self,
-        scope: Sc,
-        buf: &'a Buf,
-    ) -> Request<'a, Buf, Sc>
+    fn immediate_send<'a, Sc, Buf: ?Sized>(&self, scope: Sc, buf: &'a Buf) -> Request<'a, Buf, Sc>
     where
         Buf: 'a + Buffer,
         Sc: Scope<'a>,

--- a/src/request.rs
+++ b/src/request.rs
@@ -29,9 +29,11 @@
 
 use std::cell::Cell;
 use std::convert::TryInto;
+use std::fmt;
 use std::marker::PhantomData;
 use std::mem::{self, MaybeUninit};
 use std::ptr;
+use std::os::raw::c_int;
 
 use crate::ffi;
 use crate::ffi::{MPI_Request, MPI_Status};
@@ -63,21 +65,33 @@ fn is_null(request: MPI_Request) -> bool {
 ///
 /// 3.7.1
 #[must_use]
-#[derive(Debug)]
-pub struct Request<'a, S: Scope<'a> = StaticScope> {
+pub struct Request<'a, D: ?Sized, S: Scope<'a> = StaticScope> {
     request: MPI_Request,
+    data: &'a D,
     scope: S,
     phantom: PhantomData<Cell<&'a ()>>,
 }
 
-unsafe impl<'a, S: Scope<'a>> AsRaw for Request<'a, S> {
+impl<'a, D: ?Sized, S: Scope<'a>> fmt::Debug for Request<'a, D, S>
+where
+    D: fmt::Debug,
+{
+    fn fmt(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
+        formatter.debug_struct("Request")
+            .field("request", &self.request)
+            .field("data", &self.data)
+            .finish()
+    }
+}
+
+unsafe impl<'a, D: ?Sized, S: Scope<'a>> AsRaw for Request<'a, D, S> {
     type Raw = MPI_Request;
     fn as_raw(&self) -> Self::Raw {
         self.request
     }
 }
 
-impl<'a, S: Scope<'a>> Drop for Request<'a, S> {
+impl<'a, D: ?Sized, S: Scope<'a>> Drop for Request<'a, D, S> {
     fn drop(&mut self) {
         panic!("request was dropped without being completed");
     }
@@ -93,7 +107,9 @@ impl<'a, S: Scope<'a>> Drop for Request<'a, S> {
 /// # Examples
 ///
 /// See `examples/wait_any.rs`
-pub fn wait_any<'a, S: Scope<'a>>(requests: &mut Vec<Request<'a, S>>) -> Option<(usize, Status)> {
+pub fn wait_any<'a, D, S: Scope<'a>>(
+    requests: &mut Vec<Request<'a, D, S>>,
+) -> Option<(usize, Status)> {
     let mut mpi_requests: Vec<_> = requests.iter().map(|r| r.as_raw()).collect();
     let mut index: i32 = mpi_sys::MPI_UNDEFINED;
     let size: i32 = mpi_requests
@@ -123,7 +139,7 @@ pub fn wait_any<'a, S: Scope<'a>>(requests: &mut Vec<Request<'a, S>>) -> Option<
     }
 }
 
-impl<'a, S: Scope<'a>> Request<'a, S> {
+impl<'a, D: ?Sized, S: Scope<'a>> Request<'a, D, S> {
     /// Construct a request object from the raw MPI type.
     ///
     /// # Requirements
@@ -137,11 +153,16 @@ impl<'a, S: Scope<'a>> Request<'a, S> {
     /// - `request` must be a live MPI object.
     /// - `request` must not be used after calling `from_raw`.
     /// - Any buffers owned by `request` must live longer than `scope`.
-    pub unsafe fn from_raw(request: MPI_Request, scope: S) -> Self {
+    pub unsafe fn from_raw(
+        request: MPI_Request,
+        data: &'a D,
+        scope: S,
+    ) -> Self {
         debug_assert!(!is_null(request));
         scope.register();
         Self {
             request,
+            data,
             scope,
             phantom: Default::default(),
         }
@@ -153,24 +174,34 @@ impl<'a, S: Scope<'a>> Request<'a, S> {
     ///
     /// # Safety
     /// - The returned `MPI_Request` must be completed within the lifetime of the returned scope.
-    pub unsafe fn into_raw(self) -> (MPI_Request, S) {
+    pub unsafe fn into_raw(self) -> (MPI_Request, &'a D, S) {
         let request = ptr::read(&self.request);
+        let data = ptr::read(&self.data);
         let scope = ptr::read(&self.scope);
         let _ = ptr::read(&self.phantom);
         mem::forget(self);
         scope.unregister();
-        (request, scope)
+        (request, data, scope)
     }
 
     /// Wait for the request to finish and unregister the request object from its scope.
     /// If provided, the status is written to the referent of the given reference.
-    /// The referent `MPI_Status` object is never read.
-    fn wait_with(self, status: *mut MPI_Status) {
+    /// The referent `MPI_Status` object is never read. Also returns the data
+    /// reference.
+    fn wait_with(self, status: *mut MPI_Status) -> &'a D {
         unsafe {
-            let (mut request, _) = self.into_raw();
+            let (mut request, data, _) = self.into_raw();
             ffi::MPI_Wait(&mut request, status);
             assert!(is_null(request)); // persistent requests are not supported
+            data
         }
+    }
+
+    /// Wait for the request to finish, unregister it, and return the data
+    /// reference.
+    pub fn wait_for_data(self) -> &'a D {
+        // TODO: Just ignores the status for now, but this info might be needed.
+        self.wait_with(unsafe { ffi::RSMPI_STATUS_IGNORE })
     }
 
     /// Wait for an operation to finish.
@@ -220,8 +251,37 @@ impl<'a, S: Scope<'a>> Request<'a, S> {
                 with_uninitialized(|flag| ffi::MPI_Test(&mut request, flag, status.as_mut_ptr()));
             if flag != 0 {
                 assert!(is_null(request)); // persistent requests are not supported
-                self.into_raw();
+                let (_, _data, _) = self.into_raw();
                 Ok(Status::from_raw(status.assume_init()))
+            } else {
+                Err(self)
+            }
+        }
+    }
+
+    /// Test whether an operation has finished.
+    ///
+    /// If the operation has finished, a tuple (`Status`, saved_data) is returned.
+    /// Otherwise returns the unfinished `Request`.
+    ///
+    /// # Examples
+    ///
+    /// See `examples/immediate.rs`
+    ///
+    /// # Standard section(s)
+    ///
+    /// 3.7.3
+    pub fn test_with_data(self) -> Result<(Status, &'a D), Self> {
+        unsafe {
+            let mut status = MaybeUninit::uninit();
+            let mut request = self.as_raw();
+
+            let (_, flag) =
+                with_uninitialized(|flag| ffi::MPI_Test(&mut request, flag, status.as_mut_ptr()));
+            if flag != 0 {
+                assert!(is_null(request)); // persistent requests are not supported
+                let (_, data, _) = self.into_raw();
+                Ok((Status::from_raw(status.assume_init()), data))
             } else {
                 Err(self)
             }
@@ -251,14 +311,14 @@ impl<'a, S: Scope<'a>> Request<'a, S> {
     }
 
     /// Reduce the scope of a request.
-    pub fn shrink_scope_to<'b, S2>(self, scope: S2) -> Request<'b, S2>
+    pub fn shrink_scope_to<'b, S2>(self, scope: S2) -> Request<'b, D, S2>
     where
         'a: 'b,
         S2: Scope<'b>,
     {
         unsafe {
-            let (request, _) = self.into_raw();
-            Request::from_raw(request, scope)
+            let (request, data, _) = self.into_raw();
+            Request::from_raw(request, data, scope)
         }
     }
 }
@@ -271,34 +331,34 @@ impl<'a, S: Scope<'a>> Request<'a, S> {
 ///
 /// See `examples/immediate.rs`
 #[derive(Debug)]
-pub struct WaitGuard<'a, S: Scope<'a> = StaticScope>(Option<Request<'a, S>>);
+pub struct WaitGuard<'a, D: ?Sized, S: Scope<'a> = StaticScope>(Option<Request<'a, D, S>>);
 
-impl<'a, S: Scope<'a>> Drop for WaitGuard<'a, S> {
+impl<'a, D: ?Sized, S: Scope<'a>> Drop for WaitGuard<'a, D, S> {
     fn drop(&mut self) {
         self.0.take().expect("invalid WaitGuard").wait();
     }
 }
 
-unsafe impl<'a, S: Scope<'a>> AsRaw for WaitGuard<'a, S> {
+unsafe impl<'a, D: ?Sized, S: Scope<'a>> AsRaw for WaitGuard<'a, D, S> {
     type Raw = MPI_Request;
     fn as_raw(&self) -> Self::Raw {
         self.0.as_ref().expect("invalid WaitGuard").as_raw()
     }
 }
 
-impl<'a, S: Scope<'a>> From<WaitGuard<'a, S>> for Request<'a, S> {
-    fn from(mut guard: WaitGuard<'a, S>) -> Self {
+impl<'a, D: ?Sized, S: Scope<'a>> From<WaitGuard<'a, D, S>> for Request<'a, D, S> {
+    fn from(mut guard: WaitGuard<'a, D, S>) -> Self {
         guard.0.take().expect("invalid WaitGuard")
     }
 }
 
-impl<'a, S: Scope<'a>> From<Request<'a, S>> for WaitGuard<'a, S> {
-    fn from(req: Request<'a, S>) -> Self {
+impl<'a, D: ?Sized, S: Scope<'a>> From<Request<'a, D, S>> for WaitGuard<'a, D, S> {
+    fn from(req: Request<'a, D, S>) -> Self {
         WaitGuard(Some(req))
     }
 }
 
-impl<'a, S: Scope<'a>> WaitGuard<'a, S> {
+impl<'a, D: ?Sized, S: Scope<'a>> WaitGuard<'a, D, S> {
     fn cancel(&self) {
         if let Some(ref req) = self.0 {
             req.cancel();
@@ -315,16 +375,16 @@ impl<'a, S: Scope<'a>> WaitGuard<'a, S> {
 ///
 /// See `examples/immediate.rs`
 #[derive(Debug)]
-pub struct CancelGuard<'a, S: Scope<'a> = StaticScope>(WaitGuard<'a, S>);
+pub struct CancelGuard<'a, D: ?Sized, S: Scope<'a> = StaticScope>(WaitGuard<'a, D, S>);
 
-impl<'a, S: Scope<'a>> Drop for CancelGuard<'a, S> {
+impl<'a, D: ?Sized, S: Scope<'a>> Drop for CancelGuard<'a, D, S> {
     fn drop(&mut self) {
         self.0.cancel();
     }
 }
 
-impl<'a, S: Scope<'a>> From<CancelGuard<'a, S>> for WaitGuard<'a, S> {
-    fn from(guard: CancelGuard<'a, S>) -> Self {
+impl<'a, D: ?Sized, S: Scope<'a>> From<CancelGuard<'a, D, S>> for WaitGuard<'a, D, S> {
+    fn from(guard: CancelGuard<'a, D, S>) -> Self {
         unsafe {
             let inner = ptr::read(&guard.0);
             mem::forget(guard);
@@ -333,14 +393,14 @@ impl<'a, S: Scope<'a>> From<CancelGuard<'a, S>> for WaitGuard<'a, S> {
     }
 }
 
-impl<'a, S: Scope<'a>> From<WaitGuard<'a, S>> for CancelGuard<'a, S> {
-    fn from(guard: WaitGuard<'a, S>) -> Self {
+impl<'a, D: ?Sized, S: Scope<'a>> From<WaitGuard<'a, D, S>> for CancelGuard<'a, D, S> {
+    fn from(guard: WaitGuard<'a, D, S>) -> Self {
         CancelGuard(guard)
     }
 }
 
-impl<'a, S: Scope<'a>> From<Request<'a, S>> for CancelGuard<'a, S> {
-    fn from(req: Request<'a, S>) -> Self {
+impl<'a, D: ?Sized, S: Scope<'a>> From<Request<'a, D, S>> for CancelGuard<'a, D, S> {
+    fn from(req: Request<'a, D, S>) -> Self {
         CancelGuard(WaitGuard::from(req))
     }
 }
@@ -462,4 +522,264 @@ where
         num_requests: Default::default(),
         phantom: Default::default(),
     })
+}
+
+/// Create a scope for handling multiple request completion (such as wait_any(),
+/// test_any(), test_some(), etc.). This takes a reserve amount indicating the
+/// estimated amount of requests and a closure which will be called and passed a
+/// (scope, RequestCollection).
+///
+/// Note: Both the RequestCollection and the scope will panic on drop if not all
+/// requests have completed. Care must be taken to ensure that all requests have
+/// completed. See the `incomplete()` method for checking the number of
+/// outstanding requests.
+pub fn multiple_scope<'a, F, R, D>(reserve: usize, f: F) -> R
+where
+    D: 'a + ?Sized,
+    F: FnOnce(&LocalScope<'a>, &mut RequestCollection<'a, D>) -> R,
+{
+    f(
+        &LocalScope {
+            num_requests: Default::default(),
+            phantom: Default::default(),
+        },
+        &mut RequestCollection::new(reserve),
+    )
+}
+
+/// Request collection for managing multiple requests at the same time.
+pub struct RequestCollection<'a, D: ?Sized> {
+    /// Array of requests
+    requests: Vec<MPI_Request>,
+    /// List of data buffers attached to each request
+    data: Vec<Option<&'a D>>,
+    /// Request statuses
+    statuses: Vec<MaybeUninit<MPI_Status>>,
+    /// Pre-allocated indices buffer for use with testsome(), waitsome(), etc.
+    indices: Vec<c_int>,
+}
+
+impl<'a, D: ?Sized> RequestCollection<'a, D> {
+    /// Create a new RequestBuffer with a reserved size.
+    fn new(reserve: usize) -> RequestCollection<'a, D> {
+        let mut requests = vec![];
+        let mut data = vec![];
+        let mut statuses = vec![];
+        let mut indices = vec![];
+        requests.reserve(reserve);
+        data.reserve(reserve);
+        statuses.reserve(reserve);
+        indices.reserve(reserve);
+        RequestCollection {
+            requests,
+            data,
+            statuses,
+            indices,
+        }
+    }
+
+
+    /// Return the total number of requests that are incomplete.
+    pub fn incomplete(&self) -> usize {
+        self.data.iter().map(|data| if data.is_some() { 1 } else { 0 }).sum()
+    }
+
+    /// Add the request to the collection. This unregisters the request from the
+    /// scope. The collection then ensures that the request has completed.
+    pub fn add<S>(&mut self, req: Request<'a, D, S>) -> usize
+    where
+        S: Scope<'a>,
+    {
+        let i = self.requests.len();
+        let (req, data, _) = unsafe { req.into_raw() };
+        self.requests.push(req);
+        self.data.push(Some(data));
+        self.statuses.push(MaybeUninit::<MPI_Status>::uninit());
+        self.indices.push(0);
+        i
+    }
+
+    /// Wait for any request to complete, and return an option containing
+    /// (request_index, status, saved_data).
+    pub fn wait_any(&mut self) -> Option<(usize, Status, &'a D)> {
+         let mut i: c_int = 0;
+         let (_res, status) = unsafe {
+             let count = self.requests.len() as c_int;
+             with_uninitialized(|status| {
+                 ffi::MPI_Waitany(count, self.requests.as_mut_ptr(), &mut i, status)
+             })
+         };
+
+         let i = i as usize;
+         assert!(is_null(self.requests[i]));
+         if let Some(data) = self.data[i].take() {
+             Some((i, Status::from_raw(status), data))
+         } else {
+             None
+         }
+    }
+
+    /// Wait for some of the requests to complete, fill result with references
+    /// to the (request_index, status, saved_data) for each completed request
+    /// and return the total number of completed requests.
+    pub fn wait_some(&mut self, result: &mut [Option<(usize, Status, &'a D)>]) -> usize {
+        assert_eq!(result.len(), self.requests.len());
+        let mut count = 0;
+        unsafe {
+            let n = self.requests.len() as c_int;
+            // NOTE: not using the return value here
+            ffi::MPI_Waitsome(
+                n,
+                self.requests.as_mut_ptr(),
+                &mut count,
+                self.indices.as_mut_ptr(),
+                self.statuses.as_mut_ptr() as *mut MPI_Status,
+            );
+        };
+        let count = count as usize;
+        for (i, elm) in result.iter_mut().enumerate() {
+            elm.take();
+            if i < count {
+                let idx = self.indices[i] as usize;
+                // Persistent requests check
+                assert!(is_null(self.requests[idx]));
+                if let Some(data) = self.data[idx].take() {
+                    let status = unsafe { self.statuses[idx].assume_init() };
+                    let status = Status::from_raw(status);
+                    let _ = elm.insert((idx, status, data));
+                }
+            }
+        }
+        count
+    }
+
+    /// Wait for all requests to complete, putting (request_index, status, saved_data)
+    /// into result for every completed request.
+    pub fn wait_all(&mut self, result: &mut [Option<(usize, Status, &'a D)>]) {
+        assert_eq!(result.len(), self.requests.len());
+        let _res = unsafe {
+            ffi::MPI_Waitall(
+                self.requests.len().try_into().unwrap(),
+                self.requests.as_mut_ptr(),
+                self.statuses.as_mut_ptr() as *mut MPI_Status,
+            )
+        };
+        for (i, elm) in result.iter_mut().enumerate() {
+            // Ensure there are no persistent requests
+            assert!(is_null(self.requests[i]));
+            elm.take();
+            if let Some(data) = self.data[i].take() {
+                let status = unsafe { self.statuses[i].assume_init() };
+                let status = Status::from_raw(status);
+                let _ = elm.insert((i, status, data));
+            }
+        }
+    }
+
+    /// Test for the completion of any requests. Returns an option containing
+    /// (request_index, status, saved_data).
+    pub fn test_any(&mut self) -> Option<(usize, Status, &'a D)> {
+        let n = self.requests.len() as c_int;
+        let mut i = 0;
+        let mut flag = 0;
+        let (_, status) = unsafe {
+            with_uninitialized(|status| {
+                ffi::MPI_Testany(
+                    n,
+                    self.requests.as_mut_ptr(),
+                    &mut i,
+                    &mut flag,
+                    status,
+                )
+            })
+        };
+
+        if flag != 0 {
+            let i = i as usize;
+            assert!(is_null(self.requests[i]));
+            if let Some(data) = self.data[i].take() {
+                Some((i, Status::from_raw(status), data))
+            } else {
+                None
+            }
+        } else {
+            None
+        }
+    }
+
+    /// Test for the completion of some requests. Completed request data will be
+    /// stored in the result buffer in a tuple (request_index, status, saved_data).
+    /// None values can be ignored. The result buffer must have a length equal to
+    /// the number of requests added to this collection (the number of times `add()`
+    /// was called.
+    ///
+    /// Returns the number of requests completed.
+    pub fn test_some(&mut self, result: &mut [Option<(usize, Status, &'a D)>]) -> usize {
+        assert_eq!(result.len(), self.requests.len());
+        let n = self.requests.len() as c_int;
+        let mut count = 0;
+        unsafe {
+            ffi::MPI_Testsome(
+                n,
+                self.requests.as_mut_ptr(),
+                &mut count,
+                self.indices.as_mut_ptr(),
+                self.statuses.as_mut_ptr() as *mut MPI_Status,
+            );
+        }
+        let count = count as usize;
+        for (i, elm) in result.iter_mut().enumerate() {
+            elm.take();
+            if i < count {
+                let idx = self.indices[i] as usize;
+                assert!(is_null(self.requests[i]));
+                let status = unsafe { self.statuses[i].assume_init() };
+                if let Some(data) = self.data[idx].take() {
+                    let _ = elm.insert((idx, Status::from_raw(status), data));
+                }
+            }
+        }
+        count
+    }
+
+    /// Test for the completion of all requests. Saved data used by the
+    /// completed requests is stored in the result buffer. The result buffer
+    /// must have a length equivalent to the number of stored requests,
+    /// including those that have previously completed.
+    pub fn test_all(&mut self, result: &mut [Option<(usize, Status, &'a D)>]) -> bool {
+        assert_eq!(result.len(), self.requests.len());
+        let n = self.requests.len() as c_int;
+        let mut flag = 0;
+        unsafe {
+            ffi::MPI_Testall(
+                n,
+                self.requests.as_mut_ptr(),
+                &mut flag,
+                self.statuses.as_mut_ptr() as *mut MPI_Status,
+            );
+        }
+        if flag != 0 {
+            for (i, elm) in result.iter_mut().enumerate() {
+                assert!(is_null(self.requests[i]));
+                elm.take();
+                let status = unsafe { self.statuses[i].assume_init() };
+                if let Some(data) = self.data[i].take() {
+                    let _ = elm.insert((i, Status::from_raw(status), data));
+                }
+                // self.finish_request(i);
+            }
+            true
+        } else {
+            false
+        }
+    }
+}
+
+/// Drop implementation to ensure that all requests have actually completed.
+impl<'a, D: ?Sized> Drop for RequestCollection<'a, D> {
+    fn drop(&mut self) {
+        if !self.data.iter().all(|c| c.is_none()) {
+            panic!("some requests have not completed");
+        }
+    }
 }


### PR DESCRIPTION
* Attach data references to Request object
* Add RequestCollection object for interfacing with MPI wait_*() and test_*() functions
* Add three new examples/tests for this functionality